### PR TITLE
index: do not throw an Error when given a falsey DOM node, and a root element

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function iterator(node, root) {
   this._selects = [];
   this._rejects = [];
 
-  if (this.higher(node)) {
+  if (node && this.higher(node)) {
     throw new Error('root must be a parent or ancestor to node');
   }
 }

--- a/test/iterator.js
+++ b/test/iterator.js
@@ -150,6 +150,12 @@ describe('iterator', function() {
       assert(null == i.prev());
       assert('<em>' == format(i));
     });
+
+    it('should not throw an Error when given a falsey DOM node', function() {
+      var dom = parse('<blockquote></blockquote>');
+      var it = iterator(dom.firstChild, dom);
+      assert(null == it.next());
+    });
   });
 
   describe('atOpening() & atClosing()', function() {


### PR DESCRIPTION
This will fix: https://github.com/Automattic/html-pipe/issues/4

/cc @MatthewMueller 
