### PR TITLE
no "postinstall", use "component-*" prefix on deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,4 @@ test:
 test-browser:
 	@./node_modules/.bin/component-test browser
 
-npm:
-	@mv ./node_modules/props-component ./node_modules/props 2> /dev/null; true;
-
 .PHONY: clean test test-browser

--- a/index.js
+++ b/index.js
@@ -2,8 +2,19 @@
  * Module Dependencies
  */
 
-var xor = require('xor');
-var props = require('props');
+var xor, props;
+
+try {
+  xor = require('component-xor');
+} catch (e) {
+  xor = require('xor');
+}
+
+try {
+  props = require('component-props');
+} catch (e) {
+  props = require('props');
+}
 
 /**
  * Export `Iterator`

--- a/package.json
+++ b/package.json
@@ -8,16 +8,19 @@
     "test": "test"
   },
   "dependencies": {
-    "xor": "component/xor#0.0.3",
-    "props": "component/props#1.1.1"
+    "component-xor": "0.0.3",
+    "component-props": "1.1.1"
   },
   "devDependencies": {
     "mini-html-parser": "0.0.3",
     "mocha": "~1.17.1",
     "component-test": "~0.1.3"
   },
+  "browser": {
+    "xor": "component-xor",
+    "props": "component-props"
+  },
   "scripts": {
-    "postinstall": "make npm",
     "test": "make test"
   },
   "repository": {


### PR DESCRIPTION
Also removes the `npm` make rule.

Fixes hideous npm warnings like:

```
│   ├── props-component@1.0.3 (props) invalid (git://github.com/component/props#31ef4875f7cf38e9302fc263128cae19535b9bf9)
```

 and 

```
npm ERR! invalid: props-component@1.0.3 /Users/nrajlich/editor/node_modules/html-pipe/node_modules/dom-iterator/node_modules/props
```
