### PR TITLE
Remove duplicate require statements, Fixes #10

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,19 +2,9 @@
  * Module Dependencies
  */
 
-var xor, props;
+var xor = require('component-xor');
+var props = require('component-props');
 
-try {
-  xor = require('component-xor');
-} catch (e) {
-  xor = require('xor');
-}
-
-try {
-  props = require('component-props');
-} catch (e) {
-  props = require('props');
-}
 
 /**
  * Export `Iterator`

--- a/package.json
+++ b/package.json
@@ -8,17 +8,14 @@
     "test": "test"
   },
   "dependencies": {
-    "component-xor": "0.0.3",
+    "component-xor": "0.0.4",
     "component-props": "1.1.1"
   },
   "devDependencies": {
+    "chalk": "2.1.0",
     "mini-html-parser": "0.0.3",
     "mocha": "~1.17.1",
     "component-test": "~0.1.3"
-  },
-  "browser": {
-    "xor": "component-xor",
-    "props": "component-props"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
First off, @matthewmueller thank you for this great library.

I was running into issue #10 when trying to include your library in a Meteor project.

It seems this is due the transpilation process of Meteor, which does not take into account the package.json browser field nor resolve "require" at runtime.

Now, I'm not sure what the original purpose was for the redundant require statements. However, in my use case, removing it solved my issues and didn't raise any others. 

Let me know if anything else would need to be done to this Pull Request for it to be merged.

Thanks

